### PR TITLE
fix cklol and title parse error

### DIFF
--- a/src/JNovelDownloader/Kernel/Downloader.java
+++ b/src/JNovelDownloader/Kernel/Downloader.java
@@ -58,7 +58,7 @@ public class Downloader {
 				urlStrings[m++] = temp + n;
 			}
 		} else {
-			String temp = "http://" + urlData.domain + "/thread-"
+			String temp = "https://" + urlData.domain + "/thread-"
 					+ String.valueOf(urlData.Tid) + "-";
 			int m = 0;
 			for (int n = urlData.page; n <= toPage; n++) {

--- a/src/JNovelDownloader/UI/Frame.java
+++ b/src/JNovelDownloader/UI/Frame.java
@@ -514,7 +514,7 @@ public class Frame extends JFrame {
 			}
 		}
 		reader.close();
-		return result;
+		return result.trim();
 	}
 
 }


### PR DESCRIPTION
Hi,

The title may fail to parse due to there will be some space in the title. Let regular expression parse error.

And the original ckl0l url will cause: 301 Moved Permanently (Related to #10).

Thanks.